### PR TITLE
ci: add init commands for submodule

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,8 @@ jobs:
     working_directory: ~/landingpage.debtcollective.org
     steps:
       - checkout
+      - run: git submodule sync
+      - run: git submodule update --init
       - run:
           name: build site
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,11 @@ jobs:
     working_directory: ~/landingpage.debtcollective.org
     steps:
       - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
+      - run:
+          name: setup submodules
+          command: |
+            git submodule sync
+            git submodule update --init
       - run:
           name: build site
           command: |


### PR DESCRIPTION
**What:** Add new steps to run on our CI

**Why:** Build is failing because circle CI doesn't look for submodules

**How:**
- https://circleci.com/docs/2.0/configuration-reference/#checkout
