### PR TITLE
Fix header space

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -35,6 +35,4 @@
     integrity="sha384-Voup2lBiiyZYkRto2XWqbzxHXwzcm4A5RfdfG6466bu5LqjwwrjXCMBQBLMWh7qR"
     crossorigin="anonymous"
   ></script>
-  <script src="https://cdn.jsdelivr.net/npm/vue@2.5.16/dist/vue.min.js"></script>
-  <script src="https://s3.amazonaws.com/tds-static/js/dc-vue-header/0.0.1/index.min.js"></script>
 </head>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,8 +7,8 @@
 
     {%- include header.html -%}
 
-    <main id="top" class="header-gap">
-      <div class="page-content">
+    <main id="top">
+      <div class="page-content header-gap">
         {{ content }}
       </div>
     </main>


### PR DESCRIPTION
**What:**
- Prevent vue to being loaded
- Move class of header gap to page-content

**Why:**
- Odd behaviour on the space from content and header
- VueJS is not needed anymore after new header being added

**Screenshots:**
**Before**
![image](https://user-images.githubusercontent.com/1425162/62895865-19d60300-bd50-11e9-8b45-f812bbbb1961.png)


**After**
![image](https://user-images.githubusercontent.com/1425162/62895823-fe6af800-bd4f-11e9-987b-fa291b29bf9a.png)
