### PR TITLE
fix(header): menu-trigger have a complete box space to better pointer events

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,7 +6,9 @@
       <div class="col-3 col-lg-3 d-xl-none">
         <div class="header-col justify-content-start">
           <div id="menu-trigger" class="menu-trigger" role="button">
-            <span class="menu-stripe" />
+            <div class="menu-icon">
+              <span class="menu-stripe" />
+            </div>
           </div>
         </div>
       </div>

--- a/_sass/_components/_menu.scss
+++ b/_sass/_components/_menu.scss
@@ -2,7 +2,7 @@ $stripe-height-sm: 0.25rem;
 $stripe-width-sm: 1.5rem;
 $stripe-width-md: 4.6875rem;
 
-.menu-trigger {
+.menu-icon {
   position: relative;
   top: -$stripe-height-sm * 2;
   width: $stripe-width-sm;
@@ -11,6 +11,13 @@ $stripe-width-md: 4.6875rem;
     top: 0;
     width: $stripe-width-md;
   }
+}
+
+.menu-trigger {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  height: 100%;
 }
 
 .menu-stripe {


### PR DESCRIPTION
While the bug cannot be replicate in mobile, we still add the fix to make sure the DOM represents
the expected behaviour by making the tree lines from the _"menu-trigger"_ icon clickable

**What:** Improve the box space from _menu-trigger_ node

**Why:** Make sure the DOM communicate the actual behaviour

**How:** Add a wrapper over the icon

**Before**
![image](https://user-images.githubusercontent.com/1425162/62919331-a4dfe900-bda2-11e9-9108-8f02fbcfda1f.png)


**After**
![image](https://user-images.githubusercontent.com/1425162/62919291-8aa60b00-bda2-11e9-98b1-aee4993a503e.png)
